### PR TITLE
fix: Missing auth token returns 400 instead of 401

### DIFF
--- a/server/middlewares/isAuth.js
+++ b/server/middlewares/isAuth.js
@@ -5,7 +5,7 @@ const isAuth = async (req, res, next) => {
     const token = req.cookies.token;
     if (!token) {
       return res.status(401).json({
-        message: 'Auth Token not found'
+        message: 'Unauthorized'
       });
     }
 
@@ -14,7 +14,7 @@ const isAuth = async (req, res, next) => {
     next();
 
   } catch (_error) {
-return res.status(500).json({
+    return res.status(401).json({
         message: 'Invalid Token'
       });
   }

--- a/server/middlewares/isAuth.js
+++ b/server/middlewares/isAuth.js
@@ -4,7 +4,7 @@ const isAuth = async (req, res, next) => {
   try {
     const token = req.cookies.token;
     if (!token) {
-      return res.status(400).json({
+      return res.status(401).json({
         message: 'Auth Token not found'
       });
     }


### PR DESCRIPTION
Fixes the HTTP status code returned when the authentication token is missing. It should return 401 Unauthorized instead of 400 Bad Request.\n\nFixes #35

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Standardized missing-auth response to 401 Unauthorized instead of 400.
  * Normalized invalid-token error response to 401 instead of 500, improving consistency for authentication failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->