### PR TITLE
fix: slug field missing sparse:true

### DIFF
--- a/server/models/website.model.js
+++ b/server/models/website.model.js
@@ -39,7 +39,7 @@ const websiteSchema = new mongoose.Schema({
   },
   slug: {
     type: String,
-    unique:true,
+    unique:true, sparse: true,
 
   }
 }, { timestamps: true });


### PR DESCRIPTION
Fixes the issue where MongoDB treats multiple null values for the slug field as duplicates when the unique constraint is present. By adding sparse: true, the unique constraint only applies to documents where the slug field is defined.\n\nFixes #37

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Improved database handling of optional identifier fields to allow records without the field specified while still maintaining uniqueness among records that include it.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->