### PR TITLE
fix: Remove unused Navigate import

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { BrowserRouter, Navigate, Route, Routes } from "react-router-dom";
+import { BrowserRouter, Route, Routes } from "react-router-dom";
 import Home from "./pages/Home";
 import useGetCurrentUser from "./hooks/useGetCurrentUser";
 import { useSelector } from "react-redux";


### PR DESCRIPTION
Removes the unused Navigate import from react-router-dom in App.jsx.\n\nFixes #26

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed unused import to improve code cleanliness and reduce unnecessary dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->